### PR TITLE
feat: Add Gmail archiving script with tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,108 @@
+# Gmail Archiver Script
+
+## Description
+This script connects to a Gmail account using OAuth 2.0, fetches all emails currently in the INBOX, and then archives them. Archived emails are removed from the INBOX view but remain accessible in "All Mail" and via Gmail search.
+
+## Prerequisites
+Before running this script, ensure you have the following:
+
+1.  **Python 3.6+**: Download from [python.org](https://www.python.org/downloads/).
+2.  **Google Cloud Platform (GCP) Project**:
+    *   If you don't have one, create a project at [https://console.cloud.google.com/](https://console.cloud.google.com/).
+3.  **Gmail API Enabled**:
+    *   In your GCP project, navigate to "APIs & Services" > "Library".
+    *   Search for "Gmail API" and enable it for your project.
+4.  **OAuth 2.0 Credentials (`credentials.json`)**:
+    *   **Configure OAuth Consent Screen**:
+        *   In your GCP project, go to "APIs & Services" > "OAuth consent screen".
+        *   Choose "External" as the user type (or "Internal" if you are part of a Google Workspace organization and the app is for internal use). Click "Create".
+        *   Fill in the required application details (App name, User support email, Developer contact information).
+        *   On the "Scopes" page, click "Add or Remove Scopes".
+        *   Search for or manually input the scope: `https://www.googleapis.com/auth/gmail.modify`. Add it to your project.
+        *   Continue through the consent screen setup, adding test users if your app is in "testing" mode (newly created external apps often start in testing mode).
+        *   Ensure the consent screen is published or otherwise usable by your account.
+    *   **Create OAuth Client ID**:
+        *   Navigate to "APIs & Services" > "Credentials".
+        *   Click "+ CREATE CREDENTIALS" at the top and select "OAuth client ID".
+        *   Choose "Desktop app" as the Application type.
+        *   Give it a name (e.g., "Gmail Archiver Script Client").
+        *   Click "CREATE".
+        *   A dialog will show your Client ID and Client secret. Click "DOWNLOAD JSON" to download the credentials file.
+        *   **Rename the downloaded JSON file to `credentials.json`**.
+        *   **Place this `credentials.json` file in the same directory as the `gmail_archiver.py` script.**
+
+## Setup Instructions
+
+1.  **Clone the Repository / Download Files**:
+    *   If this is a Git repository: `git clone <repository_url>`
+    *   Alternatively, download `gmail_archiver.py`, `test_gmail_archiver.py`, and `requirements.txt` into the same directory.
+
+2.  **Install Required Libraries**:
+    *   Open a terminal or command prompt in the script's directory.
+    *   Install the necessary Python packages using pip and the `requirements.txt` file:
+        ```bash
+        pip install -r requirements.txt
+        ```
+    *   The `requirements.txt` file specifies the following libraries:
+        *   `google-api-python-client`: The Google API Client Library for Python.
+        *   `google-auth-httplib2`: The Google Authentication Library for Python using httplib2.
+        *   `google-auth-oauthlib`: The Google Authentication Library for Python using OAuthlib for user authorization.
+
+## Running the Script
+
+1.  **Execute the Script**:
+    *   Open a terminal or command prompt in the script's directory.
+    *   Run the script using:
+        ```bash
+        python gmail_archiver.py
+        ```
+
+2.  **First-Time Authorization**:
+    *   The first time you run the script, a web browser window will automatically open.
+    *   You will be prompted to log in to your Google account and then grant the script permission to "Read, compose, send, and permanently delete all your email from Gmail" (this is what the `gmail.modify` scope enables, which is necessary for reading and archiving).
+    *   After successful authorization, the script will proceed.
+
+3.  **`token.json` Creation**:
+    *   Upon successful first-time authorization, a file named `token.json` will be created in the same directory.
+    *   This file stores your OAuth 2.0 access and refresh tokens, allowing the script to run on subsequent occasions without requiring browser authorization each time.
+    *   **Important**: Keep this file secure.
+
+4.  **Logging**:
+    *   The script logs its operations and any errors to a file named `gmail_archiver.log`.
+    *   Logs are also printed to the console in real-time.
+
+## Running Tests
+The project includes a suite of unit tests to ensure the script's components function correctly. These tests mock external API calls and file system operations, so **they do not affect your actual Gmail account or local files like `token.json`**.
+
+1.  **Execute Tests**:
+    *   Open a terminal or command prompt in the script's directory.
+    *   Run the tests using:
+        ```bash
+        python -m unittest test_gmail_archiver.py
+        ```
+
+## Important Notes/Warnings
+
+*   **Archiving is a Modification**: Archiving emails removes them from your inbox. While they are not deleted and can still be found in "All Mail" and through Gmail's search functionality, your inbox view will change.
+*   **Rate Limits**: For users with exceptionally large inboxes (many thousands of emails), the script might approach or exceed Google's Gmail API rate limits. The script currently archives emails one by one. If rate limit issues occur, you might need to run the script multiple times or adapt it for batch processing (which is more complex).
+*   **Security**:
+    *   The `credentials.json` file contains sensitive information that allows the script to request access to your Gmail account.
+    *   The `token.json` file contains active tokens that grant the script access to your Gmail account as per the authorized scopes.
+    *   **Keep both `credentials.json` and `token.json` files secure and private.** Do not share them or commit them to public version control repositories. If you suspect they are compromised, revoke the script's access from your Google Account settings ([https://myaccount.google.com/permissions](https://myaccount.google.com/permissions)) and delete the `token.json` file. You may also need to delete and recreate your OAuth 2.0 client ID in the GCP console.
+
+## Troubleshooting
+
+*   **`credentials.json not found`**:
+    *   Ensure you have downloaded the OAuth 2.0 client ID JSON file from the GCP Console.
+    *   Make sure it is renamed to exactly `credentials.json`.
+    *   Confirm that `credentials.json` is in the same directory as `gmail_archiver.py`.
+*   **Authorization Errors / Scope Issues (e.g., `Error 403: access_denied` or similar during login)**:
+    *   Double-check that the Gmail API is enabled in your GCP project.
+    *   Verify that your OAuth Consent Screen is correctly configured and that you have added the `https.www.googleapis.com/auth/gmail.modify` scope.
+    *   If your GCP app is in "testing" mode, ensure the Google account you're trying to authenticate with is listed as a "Test user" in the OAuth consent screen configuration.
+*   **`ModuleNotFoundError`**:
+    *   Ensure you have installed the required libraries by running `pip install -r requirements.txt`.
+*   **`HttpError ... "rateLimitExceeded"`**:
+    *   You've made too many API requests in a short period. Wait for some time (e.g., a few hours or a day) and try running the script again. For very large inboxes, this might require multiple runs.
+*   **Token Issues (`token.json`)**:
+    *   If you encounter persistent authentication problems even with `token.json` present, try deleting `token.json` and re-running the script to go through the browser authorization flow again. This can resolve issues with corrupted or revoked tokens.

--- a/gmail_archiver.py
+++ b/gmail_archiver.py
@@ -1,0 +1,246 @@
+# gmail_archiver.py
+#
+# This script connects to a Gmail account using OAuth 2.0,
+# fetches all emails from the INBOX, and archives them.
+#
+# PREREQUISITES:
+# 1. Google Cloud Platform (GCP) Project:
+#    - If you don't have one, create a project at https://console.cloud.google.com/.
+# 2. Enable Gmail API:
+#    - In your GCP project, navigate to "APIs & Services" > "Library".
+#    - Search for "Gmail API" and enable it.
+# 3. Configure OAuth Consent Screen:
+#    - In "APIs & Services" > "OAuth consent screen".
+#    - Choose "External" (or "Internal" if applicable).
+#    - Fill in the required information (App name, User support email, Developer contact information).
+#    - Add the scope: "../auth/gmail.modify"
+# 4. Create OAuth 2.0 Credentials:
+#    - In "APIs & Services" > "Credentials".
+#    - Click "Create Credentials" > "OAuth client ID".
+#    - Select "Desktop app" as the Application type.
+#    - Name it (e.g., "Gmail Archiver Script").
+#    - After creation, download the JSON file.
+#    - **IMPORTANT**: Rename the downloaded JSON file to `credentials.json`
+#      and place it in the same directory as this script.
+
+import os
+import logging
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# --- Configuration ---
+SCOPES = ['https://www.googleapis.com/auth/gmail.modify']  # Read/write access (needed to archive)
+LOG_FILE = 'gmail_archiver.log'
+TOKEN_FILE = 'token.json' # Stores user's access and refresh tokens
+
+# --- Logging Setup ---
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(levelname)s - %(message)s',
+    handlers=[
+        logging.FileHandler(LOG_FILE),
+        logging.StreamHandler()  # Also print to console
+    ]
+)
+logger = logging.getLogger(__name__)
+
+def authenticate_gmail():
+    """Authenticates the user with Gmail API using OAuth 2.0.
+    Manages token creation and refresh.
+    Returns:
+        googleapiclient.discovery.Resource: An authorized Gmail API service instance.
+    """
+    creds = None
+    creds_were_modified_and_need_saving = False
+
+    if os.path.exists(TOKEN_FILE):
+        try:
+            creds = Credentials.from_authorized_user_file(TOKEN_FILE, SCOPES)
+            logger.info("Loaded credentials from token.json")
+        except Exception as e:
+            logger.warning(f"Could not load token.json: {e}. Will attempt to re-authenticate.")
+            creds = None
+
+    if creds: # If token file loaded something
+        if creds.valid:
+            logger.info("Existing credentials are valid.")
+        elif creds.expired and creds.refresh_token:
+            logger.info("Existing credentials expired. Attempting to refresh token...")
+            try:
+                creds.refresh(Request())
+                logger.info("Token refreshed successfully.")
+                creds_were_modified_and_need_saving = True # Refreshed token needs saving
+            except Exception as e:
+                logger.error(f"Error refreshing token: {e}. Will attempt new OAuth flow.")
+                creds = None # Nullify to trigger new flow logic below
+        else: # Not valid, and not refreshable (e.g. revoked, malformed, no refresh_token)
+            logger.info("Loaded credentials are not valid and cannot be refreshed. Attempting new OAuth flow.")
+            creds = None # Nullify to trigger new flow logic below
+    
+    # If creds are None at this point (either never loaded, failed to load, failed to refresh, or invalid and not refreshable)
+    # then we need to attempt a new OAuth flow.
+    if not creds: 
+        logger.info("Attempting new OAuth flow as existing credentials are not sufficient or available.")
+        if not os.path.exists('credentials.json'):
+            logger.error("OAuth credentials file 'credentials.json' not found.")
+            logger.error("Please follow the PREREQUISITES section in the script's comments to set it up.")
+            return None
+        try:
+            flow = InstalledAppFlow.from_client_secrets_file('credentials.json', SCOPES)
+            creds_new = flow.run_local_server(port=0) # Use a temporary variable
+            if creds_new: # Check if new creds were actually obtained
+                creds = creds_new # Assign to main creds variable
+                logger.info("OAuth flow completed. Credentials obtained.")
+                creds_were_modified_and_need_saving = True # New token needs saving
+            else:
+                logger.error("OAuth flow did not return credentials.")
+                # creds remains None, will be caught by final check
+        except FileNotFoundError: 
+            logger.error("credentials.json not found during OAuth flow. Please ensure it's in the same directory.")
+            return None
+        except Exception as e:
+            logger.error(f"Error during OAuth flow: {e}")
+            return None
+
+    # Save token if it was modified (refreshed or new) and creds are available
+    if creds_were_modified_and_need_saving and creds: 
+        try:
+            with open(TOKEN_FILE, 'w') as token_file:
+                token_file.write(creds.to_json())
+            logger.info(f"Credentials saved to {TOKEN_FILE}")
+        except Exception as e:
+            logger.error(f"Error saving token to {TOKEN_FILE}: {e}")
+            # If saving fails, current session might still proceed with 'creds'
+            # but subsequent runs will have issues. For this script, we can proceed.
+
+    # Final check for valid credentials
+    if not creds or not creds.valid:
+        logger.error("Failed to obtain valid credentials after all attempts.")
+        return None
+
+    try:
+        service = build('gmail', 'v1', credentials=creds)
+        logger.info("Gmail API service built successfully.")
+        return service
+    except HttpError as error:
+        logger.error(f"An API error occurred while building the service: {error}")
+        return None
+    except Exception as e:
+        logger.error(f"An unexpected error occurred while building the service: {e}")
+        return None
+
+def fetch_inbox_emails(service):
+    """Fetches all emails from the INBOX.
+    Args:
+        service: Authorized Gmail API service instance.
+    Returns:
+        list: A list of message IDs from the INBOX. Returns empty list on error.
+    """
+    logger.info("Fetching emails from INBOX...")
+    message_ids = []
+    try:
+        # Initial request to get the first page of messages
+        request = service.users().messages().list(userId='me', labelIds=['INBOX'])
+        while request is not None:
+            response = request.execute()
+            messages = response.get('messages', [])
+            if not messages:
+                logger.info("No messages found in INBOX.")
+                break
+            
+            current_page_ids = [msg['id'] for msg in messages]
+            message_ids.extend(current_page_ids)
+            logger.info(f"Fetched {len(current_page_ids)} email IDs from this page.")
+            
+            # Check if there's a next page
+            request = service.users().messages().list_next(previous_request=request, previous_response=response)
+        
+        logger.info(f"Total email IDs fetched from INBOX: {len(message_ids)}")
+        return message_ids
+    except HttpError as error:
+        logger.error(f"An API error occurred while fetching emails: {error}")
+        return []
+    except Exception as e:
+        logger.error(f"An unexpected error occurred while fetching emails: {e}")
+        return []
+
+def archive_emails(service, message_ids):
+    """Archives a list of emails by removing the INBOX label.
+    Args:
+        service: Authorized Gmail API service instance.
+        message_ids (list): A list of email message IDs to archive.
+    Returns:
+        int: Count of successfully archived emails.
+    """
+    if not message_ids:
+        logger.info("No emails to archive.")
+        return 0
+
+    logger.info(f"Starting to archive {len(message_ids)} emails...")
+    archived_count = 0
+    # Gmail API recommends batching requests if you're modifying many messages,
+    # but for simplicity, we'll archive one by one here.
+    # For larger volumes, consider using batch requests.
+    # https://developers.google.com/gmail/api/guides/batch
+    for i, message_id in enumerate(message_ids):
+        try:
+            # To archive, we remove the 'INBOX' label from the message.
+            # Other labels (e.g., custom labels) will remain.
+            # The 'UNREAD' label is also typically removed when archiving from INBOX,
+            # but the primary action for "archiving" is removing INBOX.
+            # If you specifically want to mark as read, add 'removeLabelIds': ['UNREAD']
+            body = {'removeLabelIds': ['INBOX']}
+            service.users().messages().modify(
+                userId='me',
+                id=message_id,
+                body=body
+            ).execute()
+            archived_count += 1
+            logger.info(f"Archived email {i+1}/{len(message_ids)} (ID: {message_id})")
+        except HttpError as error:
+            logger.error(f"API error archiving email ID {message_id}: {error}")
+            # Optionally, decide if you want to stop or continue on error
+        except Exception as e:
+            logger.error(f"Unexpected error archiving email ID {message_id}: {e}")
+
+    logger.info(f"Successfully archived {archived_count} out of {len(message_ids)} emails.")
+    return archived_count
+
+def main():
+    """Main function to orchestrate email archiving."""
+    logger.info("Gmail Archiver Script started.")
+    
+    service = authenticate_gmail()
+    
+    if not service:
+        logger.error("Could not authenticate with Gmail. Exiting.")
+        return
+
+    inbox_message_ids = fetch_inbox_emails(service)
+    
+    if not inbox_message_ids:
+        logger.info("No emails found in INBOX or an error occurred. Exiting.")
+        return
+        
+    archive_emails(service, inbox_message_ids)
+    
+    logger.info("Gmail Archiver Script finished.")
+
+if __name__ == '__main__':
+    main()
+    # To run this script:
+    # 1. Make sure you have `credentials.json` in the same directory.
+    # 2. Install necessary libraries:
+    #    pip install --upgrade google-api-python-client google-auth-httplib2 google-auth-oauthlib
+    # 3. Run: python gmail_archiver.py
+    #
+    # The first time you run it, a browser window will open for you to authorize
+    # the script to access your Gmail account. After successful authorization,
+    # a `token.json` file will be created, storing your credentials for future runs.
+    # Subsequent runs will use `token.json` and should not require browser interaction
+    # unless the token expires or is revoked.
+    #
+    # Check gmail_archiver.log for detailed logs.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+google-api-python-client
+google-auth-httplib2
+google-auth-oauthlib

--- a/test_gmail_archiver.py
+++ b/test_gmail_archiver.py
@@ -1,0 +1,440 @@
+# test_gmail_archiver.py
+
+import unittest
+from unittest.mock import patch, MagicMock, mock_open, call
+import os
+import logging
+
+# Import the script to be tested
+import gmail_archiver
+
+# Suppress logging output during tests for cleaner test results
+# You can enable it for debugging by commenting out the next line
+logging.disable(logging.CRITICAL)
+
+
+class TestGmailArchiver(unittest.TestCase):
+
+    def setUp(self):
+        # Reset any potentially problematic global state if necessary,
+        # e.g., if gmail_archiver.logger was configured in a way that affects tests.
+        # For now, disabling logging globally in tests is simpler.
+        pass
+
+    @patch('gmail_archiver.os.path.exists')
+    @patch('gmail_archiver.InstalledAppFlow.from_client_secrets_file')
+    @patch('gmail_archiver.build')
+    @patch('gmail_archiver.Credentials.from_authorized_user_file')
+    def test_authenticate_gmail_token_valid(self, mock_from_user_file, mock_build, mock_flow, mock_exists):
+        """Test authentication when token.json exists and is valid."""
+        mock_exists.return_value = True  # token.json exists
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_creds.expired = False
+        mock_creds.refresh_token = True # Has a refresh token just in case, though not used here
+        mock_from_user_file.return_value = mock_creds
+        
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        service = gmail_archiver.authenticate_gmail()
+
+        mock_from_user_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, gmail_archiver.SCOPES)
+        mock_build.assert_called_once_with('gmail', 'v1', credentials=mock_creds)
+        self.assertEqual(service, mock_service)
+        mock_flow.assert_not_called() # Should not start new flow
+
+    @patch('gmail_archiver.os.path.exists')
+    @patch('gmail_archiver.InstalledAppFlow.from_client_secrets_file')
+    @patch('gmail_archiver.build')
+    @patch('gmail_archiver.Credentials.from_authorized_user_file')
+    def test_authenticate_gmail_token_expired_refresh_success(self, mock_from_user_file, mock_build, mock_flow, mock_exists):
+        """Test authentication when token.json exists, is expired, and refresh succeeds."""
+        mock_exists.side_effect = lambda path: path == gmail_archiver.TOKEN_FILE # token.json exists
+        
+        mock_creds = MagicMock()
+        mock_creds.valid = False # Initially invalid
+        mock_creds.expired = True
+        mock_creds.refresh_token = True
+        
+        # Make creds valid after refresh
+        def refresh_creds_effect(request):
+            mock_creds.valid = True 
+            mock_creds.expired = False
+        mock_creds.refresh.side_effect = refresh_creds_effect
+        
+        mock_from_user_file.return_value = mock_creds
+        
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        # Mock open for saving the refreshed token
+        with patch('builtins.open', mock_open()) as mock_file:
+            service = gmail_archiver.authenticate_gmail()
+
+        mock_from_user_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, gmail_archiver.SCOPES)
+        mock_creds.refresh.assert_called_once()
+        mock_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, 'w') # Token saved
+        mock_build.assert_called_once_with('gmail', 'v1', credentials=mock_creds)
+        self.assertEqual(service, mock_service)
+        mock_flow.assert_not_called()
+
+    @patch('gmail_archiver.os.path.exists')
+    @patch('gmail_archiver.InstalledAppFlow.from_client_secrets_file')
+    @patch('gmail_archiver.build')
+    @patch('gmail_archiver.Credentials.from_authorized_user_file')
+    def test_authenticate_gmail_token_expired_refresh_fail(self, mock_from_user_file, mock_build, mock_flow_constructor, mock_exists):
+        """Test authentication when token.json exists, is expired, and refresh fails."""
+        
+        # token.json exists, credentials.json also exists for the fallback flow
+        def os_path_exists_side_effect(path):
+            if path == gmail_archiver.TOKEN_FILE:
+                return True # token.json exists
+            if path == 'credentials.json':
+                return True # credentials.json exists for fallback
+            return False
+        mock_exists.side_effect = os_path_exists_side_effect
+
+        mock_initial_creds = MagicMock()
+        mock_initial_creds.valid = False      # Credentials are not valid
+        mock_initial_creds.expired = True     # Should attempt refresh
+        mock_initial_creds.refresh_token = "mock_refresh_token" # Should attempt refresh
+        mock_initial_creds.refresh.side_effect = Exception("Refresh failed") # Refresh attempt fails
+        mock_from_user_file.return_value = mock_initial_creds
+        
+        # Mock the flow that should run after refresh fails
+        mock_flow_instance = MagicMock()
+        mock_new_creds = MagicMock()
+        mock_new_creds.valid = True # New creds from flow are valid
+        mock_flow_instance.run_local_server.return_value = mock_new_creds
+        mock_flow_constructor.return_value = mock_flow_instance
+        
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        with patch('builtins.open', mock_open()) as mock_file:
+            service = gmail_archiver.authenticate_gmail()
+
+        mock_from_user_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, gmail_archiver.SCOPES)
+        mock_initial_creds.refresh.assert_called_once()
+        mock_flow_constructor.assert_called_once_with('credentials.json', gmail_archiver.SCOPES)
+        mock_flow_instance.run_local_server.assert_called_once_with(port=0)
+        mock_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, 'w') # New token saved
+        mock_build.assert_called_once_with('gmail', 'v1', credentials=mock_new_creds)
+        self.assertEqual(service, mock_service)
+        # mock_initial_creds.refresh.assert_called_once() # We are not testing this mock directly here,
+                                                        # but rather the consequence of its failure.
+
+
+    @patch('gmail_archiver.os.path.exists')
+    @patch('gmail_archiver.InstalledAppFlow.from_client_secrets_file')
+    @patch('gmail_archiver.build')
+    def test_authenticate_gmail_no_token_new_flow_success(self, mock_build, mock_flow_constructor, mock_exists):
+        """Test authentication when no token.json, new OAuth flow runs."""
+        # token.json does not exist, credentials.json does
+        mock_exists.side_effect = lambda path: path == 'credentials.json'
+
+        mock_flow_instance = MagicMock()
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_flow_instance.run_local_server.return_value = mock_creds
+        mock_flow_constructor.return_value = mock_flow_instance
+        
+        mock_service = MagicMock()
+        mock_build.return_value = mock_service
+
+        with patch('builtins.open', mock_open()) as mock_file:
+            service = gmail_archiver.authenticate_gmail()
+
+        mock_exists.assert_any_call(gmail_archiver.TOKEN_FILE) # Check for token.json
+        mock_exists.assert_any_call('credentials.json')    # Check for credentials.json
+        mock_flow_constructor.assert_called_once_with('credentials.json', gmail_archiver.SCOPES)
+        mock_flow_instance.run_local_server.assert_called_once_with(port=0)
+        mock_file.assert_called_once_with(gmail_archiver.TOKEN_FILE, 'w')
+        mock_build.assert_called_once_with('gmail', 'v1', credentials=mock_creds)
+        self.assertEqual(service, mock_service)
+
+    @patch('gmail_archiver.os.path.exists')
+    def test_authenticate_gmail_credentials_json_not_found(self, mock_exists):
+        """Test authentication when credentials.json is not found."""
+        # token.json does not exist, credentials.json also does not exist
+        mock_exists.return_value = False 
+        
+        service = gmail_archiver.authenticate_gmail()
+        self.assertIsNone(service)
+        # Check that it logged an error (requires more complex logging capture or checking stderr)
+
+    @patch('gmail_archiver.os.path.exists')
+    @patch('gmail_archiver.InstalledAppFlow.from_client_secrets_file')
+    def test_authenticate_gmail_flow_exception(self, mock_flow_constructor, mock_exists):
+        """Test authentication when OAuth flow raises an exception."""
+        mock_exists.side_effect = lambda path: path == 'credentials.json' # No token, creds.json exists
+        mock_flow_constructor.side_effect = Exception("Flow error")
+
+        service = gmail_archiver.authenticate_gmail()
+        self.assertIsNone(service)
+
+    @patch('gmail_archiver.build', side_effect=Exception("Build error"))
+    @patch('gmail_archiver.Credentials.from_authorized_user_file')
+    @patch('gmail_archiver.os.path.exists', return_value=True) # token.json exists
+    def test_authenticate_gmail_build_service_fails(self, mock_exists, mock_from_user_file, mock_build):
+        """Test authentication when building the Gmail service fails."""
+        mock_creds = MagicMock()
+        mock_creds.valid = True
+        mock_from_user_file.return_value = mock_creds
+
+        service = gmail_archiver.authenticate_gmail()
+        self.assertIsNone(service)
+        mock_build.assert_called_once()
+
+
+    def test_fetch_inbox_emails_success_single_page(self):
+        """Test fetching emails successfully with a single page of results."""
+        mock_service = MagicMock()
+        mock_messages_resource = mock_service.users().messages()
+        
+        # Simulate API response for list method
+        mock_list_response = {
+            'messages': [
+                {'id': 'msg1', 'threadId': 'thread1'},
+                {'id': 'msg2', 'threadId': 'thread2'}
+            ]
+            # No 'nextPageToken' means it's the only page
+        }
+        # list().execute() is the first call
+        mock_list_initial_request = MagicMock()
+        mock_list_initial_request.execute.return_value = mock_list_response
+        mock_messages_resource.list.return_value = mock_list_initial_request
+        
+        # list_next() is called, and for a single page, it should return None
+        mock_messages_resource.list_next.return_value = None 
+
+        message_ids = gmail_archiver.fetch_inbox_emails(mock_service)
+
+        mock_messages_resource.list.assert_called_once_with(userId='me', labelIds=['INBOX'])
+        mock_list_initial_request.execute.assert_called_once() # Execute on the first request
+        
+        # list_next should be called once, after processing the first (and only) page
+        mock_messages_resource.list_next.assert_called_once_with(
+            previous_request=mock_list_initial_request, 
+            previous_response=mock_list_response
+        )
+        self.assertEqual(message_ids, ['msg1', 'msg2'])
+
+    def test_fetch_inbox_emails_success_multiple_pages(self):
+        """Test fetching emails successfully with pagination."""
+        mock_service = MagicMock()
+        mock_messages_resource = mock_service.users().messages()
+
+        # Simulate API responses for pagination
+        mock_list_response_page1 = {
+            'messages': [{'id': 'msg1'}],
+            'nextPageToken': 'pageToken123'
+        }
+        mock_list_response_page2 = {
+            'messages': [{'id': 'msg2'}]
+            # No 'nextPageToken' means this is the last page
+        }
+        
+        # list().execute() will be called first
+        # list_next().execute() will be called for the second page
+        # Need to make list() and list_next() distinct mocks if list_next is called on the original list() object
+        
+        mock_list_initial_request = MagicMock()
+        mock_list_initial_request.execute.return_value = mock_list_response_page1
+        mock_messages_resource.list.return_value = mock_list_initial_request
+
+        mock_list_next_request = MagicMock()
+        mock_list_next_request.execute.return_value = mock_list_response_page2
+        # This setup assumes list_next is called with (previous_request, previous_response)
+        mock_messages_resource.list_next.side_effect = [mock_list_next_request, None]
+
+
+        message_ids = gmail_archiver.fetch_inbox_emails(mock_service)
+
+        # Check calls
+        mock_messages_resource.list.assert_called_once_with(userId='me', labelIds=['INBOX'])
+        mock_list_initial_request.execute.assert_called_once()
+        
+        # Check that list_next was called correctly
+        calls_to_list_next = mock_messages_resource.list_next.call_args_list
+        self.assertEqual(len(calls_to_list_next), 2)
+        self.assertEqual(calls_to_list_next[0][1]['previous_request'], mock_list_initial_request)
+        self.assertEqual(calls_to_list_next[0][1]['previous_response'], mock_list_response_page1)
+        
+        # Check that the second request (from list_next) was executed
+        mock_list_next_request.execute.assert_called_once()
+
+        self.assertEqual(message_ids, ['msg1', 'msg2'])
+
+
+    def test_fetch_inbox_emails_empty(self):
+        """Test fetching emails when the inbox is empty."""
+        mock_service = MagicMock()
+        mock_messages_resource = mock_service.users().messages()
+        mock_list_response = {'messages': []} # Empty messages list
+        mock_messages_resource.list.return_value.execute.return_value = mock_list_response
+
+        message_ids = gmail_archiver.fetch_inbox_emails(mock_service)
+
+        mock_messages_resource.list.assert_called_once_with(userId='me', labelIds=['INBOX'])
+        self.assertEqual(message_ids, [])
+
+    def test_fetch_inbox_emails_no_messages_key(self):
+        """Test fetching emails when the response has no 'messages' key."""
+        mock_service = MagicMock()
+        mock_messages_resource = mock_service.users().messages()
+        mock_list_response = {} # No 'messages' key
+        mock_messages_resource.list.return_value.execute.return_value = mock_list_response
+
+        message_ids = gmail_archiver.fetch_inbox_emails(mock_service)
+
+        mock_messages_resource.list.assert_called_once_with(userId='me', labelIds=['INBOX'])
+        self.assertEqual(message_ids, [])
+
+    def test_fetch_inbox_emails_api_error(self):
+        """Test fetching emails when the API call raises an error."""
+        mock_service = MagicMock()
+        mock_messages_resource = mock_service.users().messages()
+        mock_messages_resource.list.return_value.execute.side_effect = gmail_archiver.HttpError(
+            MagicMock(status=500), b"API Error"
+        )
+
+        message_ids = gmail_archiver.fetch_inbox_emails(mock_service)
+        self.assertEqual(message_ids, [])
+        # Check logging for error (optional, requires log capture)
+
+    def test_archive_emails_success(self):
+        """Test archiving emails successfully."""
+        mock_service = MagicMock()
+        mock_users = mock_service.users.return_value
+        mock_messages = mock_users.messages.return_value
+        
+        # When mock_messages.modify is called, it returns a new mock (mock_modify_request)
+        # each time to simulate separate request objects.
+        # We need to collect these to check their .execute() calls.
+        execute_mocks = [MagicMock() for _ in range(3)]
+        mock_modify_requests = [MagicMock(execute=exec_mock) for exec_mock in execute_mocks]
+        
+        # Set modify to return a different mock_modify_request on each call
+        mock_messages.modify.side_effect = mock_modify_requests
+
+        message_ids = ['msg1', 'msg2', 'msg3']
+        archived_count = gmail_archiver.archive_emails(mock_service, message_ids)
+
+        expected_body = {'removeLabelIds': ['INBOX']}
+        calls_to_modify = [
+            call(userId='me', id='msg1', body=expected_body),
+            call(userId='me', id='msg2', body=expected_body),
+            call(userId='me', id='msg3', body=expected_body)
+        ]
+        mock_messages.modify.assert_has_calls(calls_to_modify, any_order=False)
+        
+        for exec_mock in execute_mocks:
+            exec_mock.assert_called_once() # Each execute mock should be called once
+            
+        self.assertEqual(archived_count, len(message_ids))
+
+    def test_archive_emails_empty_list(self):
+        """Test archiving with an empty list of message IDs."""
+        mock_service = MagicMock()
+        mock_users = mock_service.users.return_value
+        mock_messages = mock_users.messages.return_value
+        
+        message_ids = []
+        archived_count = gmail_archiver.archive_emails(mock_service, message_ids)
+
+        mock_messages.modify.assert_not_called()
+        self.assertEqual(archived_count, 0)
+
+    def test_archive_emails_api_error_on_one_email(self):
+        """Test archiving when an API error occurs for one email."""
+        mock_service = MagicMock()
+        mock_users = mock_service.users.return_value
+        mock_messages = mock_users.messages.return_value
+
+        # Setup three separate execute mocks for three calls to modify
+        execute_mock_msg1 = MagicMock()
+        execute_mock_msg2 = MagicMock()
+        execute_mock_msg3 = MagicMock()
+
+        # Define side effects for each execute call
+        execute_mock_msg1.return_value = None # Success for msg1
+        execute_mock_msg2.side_effect = gmail_archiver.HttpError(MagicMock(status=500), b"API Error on msg2") # Error for msg2
+        execute_mock_msg3.return_value = None # Success for msg3
+        
+        # Each call to modify returns a mock that has one of these execute mocks
+        mock_modify_request_msg1 = MagicMock(execute=execute_mock_msg1)
+        mock_modify_request_msg2 = MagicMock(execute=execute_mock_msg2)
+        mock_modify_request_msg3 = MagicMock(execute=execute_mock_msg3)
+
+        mock_messages.modify.side_effect = [
+            mock_modify_request_msg1,
+            mock_modify_request_msg2,
+            mock_modify_request_msg3
+        ]
+        
+        message_ids = ['msg1', 'msg2', 'msg3']
+        archived_count = gmail_archiver.archive_emails(mock_service, message_ids)
+
+        expected_body = {'removeLabelIds': ['INBOX']}
+        calls_to_modify = [
+            call(userId='me', id='msg1', body=expected_body),
+            call(userId='me', id='msg2', body=expected_body),
+            call(userId='me', id='msg3', body=expected_body)
+        ]
+        mock_messages.modify.assert_has_calls(calls_to_modify, any_order=False)
+        
+        execute_mock_msg1.assert_called_once()
+        execute_mock_msg2.assert_called_once()
+        execute_mock_msg3.assert_called_once()
+        
+        self.assertEqual(archived_count, 2) # msg1 and msg3 should be archived
+
+    @patch('gmail_archiver.authenticate_gmail')
+    @patch('gmail_archiver.fetch_inbox_emails')
+    @patch('gmail_archiver.archive_emails')
+    def test_main_flow_successful_archival(self, mock_archive, mock_fetch, mock_auth):
+        """Test the main function flow with successful authentication, fetch, and archive."""
+        mock_service = MagicMock()
+        mock_auth.return_value = mock_service
+        
+        mock_message_ids = ['id1', 'id2']
+        mock_fetch.return_value = mock_message_ids
+        
+        mock_archive.return_value = len(mock_message_ids)
+
+        gmail_archiver.main()
+
+        mock_auth.assert_called_once()
+        mock_fetch.assert_called_once_with(mock_service)
+        mock_archive.assert_called_once_with(mock_service, mock_message_ids)
+
+    @patch('gmail_archiver.authenticate_gmail', return_value=None)
+    @patch('gmail_archiver.fetch_inbox_emails')
+    @patch('gmail_archiver.archive_emails')
+    def test_main_flow_auth_fails(self, mock_archive, mock_fetch, mock_auth):
+        """Test the main function flow when authentication fails."""
+        gmail_archiver.main()
+        mock_auth.assert_called_once()
+        mock_fetch.assert_not_called()
+        mock_archive.assert_not_called()
+
+    @patch('gmail_archiver.authenticate_gmail')
+    @patch('gmail_archiver.fetch_inbox_emails', return_value=[]) # No emails fetched
+    @patch('gmail_archiver.archive_emails')
+    def test_main_flow_no_emails_to_archive(self, mock_archive, mock_fetch, mock_auth):
+        """Test the main function flow when no emails are fetched."""
+        mock_service = MagicMock()
+        mock_auth.return_value = mock_service
+
+        gmail_archiver.main()
+
+        mock_auth.assert_called_once()
+        mock_fetch.assert_called_once_with(mock_service)
+        mock_archive.assert_not_called() # archive_emails should not be called if list is empty
+
+if __name__ == '__main__':
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)
+    # Re-enable logging if it was disabled for tests, if running interactively
+    # logging.disable(logging.NOTSET)


### PR DESCRIPTION
This commit introduces a Python script (`gmail_archiver.py`) that connects to your Gmail account via the Gmail API and archives all emails from the INBOX.

Key features:
- OAuth 2.0 authentication for secure API access.
- Fetches all messages from the INBOX, handling pagination.
- Archives messages by removing the 'INBOX' label.
- Robust error handling and logging (to console and `gmail_archiver.log`).
- Includes comprehensive setup instructions in `README.md`, covering API key generation, library installation, and script execution.
- A suite of unit tests (`test_gmail_archiver.py`) using `unittest.mock` ensures the script's logic is correct without making live API calls. All tests are passing.
- `requirements.txt` lists necessary dependencies.

The script now also correctly handles token refresh failures by falling back to a full OAuth flow, improving its robustness.